### PR TITLE
Use relative paths in .gp file

### DIFF
--- a/src/main/de/linearbits/subframe/render/GnuPlot.java
+++ b/src/main/de/linearbits/subframe/render/GnuPlot.java
@@ -101,7 +101,7 @@ public abstract class GnuPlot<T extends Plot<?>> {
         }
 
         // Write gnuplot file
-        String gpFilename = filename;
+        String gpFilename = ".\\" + new File(filename).getName();
         if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
             gpFilename = gpFilename.replaceAll("\\\\", "\\\\\\\\");
         }
@@ -169,6 +169,7 @@ public abstract class GnuPlot<T extends Plot<?>> {
 
         // Run gnuplot
         ProcessBuilder b = new ProcessBuilder();
+        b.directory(new File(file).getParentFile());
         b.command("gnuplot", file + ".gp");
         Process p = b.start();
         StreamReader in = new StreamReader(p.getInputStream());


### PR DESCRIPTION
Give getSource() a relative path.
Set working directory for ProcessBuilder.