### PR TITLE
Fixes for clustered lines plots.

### DIFF
--- a/src/main/de/linearbits/subframe/graph/PlotHistogramClustered.java
+++ b/src/main/de/linearbits/subframe/graph/PlotHistogramClustered.java
@@ -24,7 +24,7 @@ package de.linearbits.subframe.graph;
 public class PlotHistogramClustered extends Plot<Series3D> {
 
     /**
-     * Will plot a clustered histogram
+     * Will plot a clustered histogram. Y determines the label of the series.
      * 
      * @param title
      * @param labels

--- a/src/main/de/linearbits/subframe/graph/PlotLinesClustered.java
+++ b/src/main/de/linearbits/subframe/graph/PlotLinesClustered.java
@@ -24,7 +24,7 @@ package de.linearbits.subframe.graph;
 public class PlotLinesClustered extends Plot<Series3D> {
 
     /**
-     * Will plot a clustered lines plot
+     * Will plot a clustered lines plot. Y determines the label of the series.
      * 
      * @param title
      * @param labels

--- a/src/main/de/linearbits/subframe/graph/Series3D.java
+++ b/src/main/de/linearbits/subframe/graph/Series3D.java
@@ -34,7 +34,10 @@ import de.linearbits.subframe.io.CSVLine;
  * @author Fabian Prasser
  */
 public class Series3D extends Series<Point3D>{
-
+    
+    /** Whether multiple values must not be specified for the same x-value*/
+    private boolean strict = true;
+    
     /**
      * Creates an empty series
      */
@@ -61,7 +64,7 @@ public class Series3D extends Series<Point3D>{
         
         this(file, getDefaultSelector(), xField, yField, yAnalyzer, zAnalyzer);
     }
-    
+
     /**
      * Creates a series by selecting rows and taking three values
      * 
@@ -78,7 +81,6 @@ public class Series3D extends Series<Point3D>{
         this(file, getDefaultSelector(), xField, yField, zField);
     }
     
-
     /**
      * Creates a series by selecting rows, 
      * grouping by x and y and applying the analyzer to z 
@@ -98,7 +100,6 @@ public class Series3D extends Series<Point3D>{
         this(file, getDefaultSelector(), xField, yField, zField, analyzer);
     }
     
-
     /**
      * Creates a series by selecting rows and taking two values plus a constant y-value
      * 
@@ -164,6 +165,7 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
+
     /**
      * Creates a series by selecting rows and taking three values
      * 
@@ -236,30 +238,6 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
     /**
      * Creates a series by selecting rows and taking two values plus a constant y-value
      * 
@@ -288,6 +266,7 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
+
     /**
      * Creates a series by selecting rows, 
      * grouping by a constant x and applying two analyzers to y,
@@ -336,6 +315,29 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
 
     /**
      * Creates a series by selecting rows and taking a constant and two values
@@ -364,7 +366,6 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
-
     /**
      * Creates a series by selecting rows, taking a constant x 
      * grouping by y and applying the analyzer to z 
@@ -429,6 +430,7 @@ public class Series3D extends Series<Point3D>{
         this(file, getDefaultSelector(), xLabel, yField, yAnalyzer, zAnalyzer);
     }
     
+
     /**
      * Creates a series by selecting rows and taking a constant and two values
      * 
@@ -464,4 +466,21 @@ public class Series3D extends Series<Point3D>{
 
         this(file, getDefaultSelector(), xLabel, yField, zField, analyzer);
     }
-}
+    
+    /**
+     * Returns whether multiple values must not be specified for the same x-value.
+     * @return
+     */
+    public boolean isStrict() {
+        return this.strict;
+    }
+    
+
+    /**
+     * Sets whether multiple values must not be specified for the same x-value.
+     * @param strict
+     */
+    public void setStrict(boolean strict) {
+        this.strict = strict;
+    }
+ }

--- a/src/main/de/linearbits/subframe/graph/Series3D.java
+++ b/src/main/de/linearbits/subframe/graph/Series3D.java
@@ -64,7 +64,7 @@ public class Series3D extends Series<Point3D>{
         
         this(file, getDefaultSelector(), xField, yField, yAnalyzer, zAnalyzer);
     }
-
+    
     /**
      * Creates a series by selecting rows and taking three values
      * 
@@ -81,6 +81,7 @@ public class Series3D extends Series<Point3D>{
         this(file, getDefaultSelector(), xField, yField, zField);
     }
     
+
     /**
      * Creates a series by selecting rows, 
      * grouping by x and y and applying the analyzer to z 
@@ -100,6 +101,7 @@ public class Series3D extends Series<Point3D>{
         this(file, getDefaultSelector(), xField, yField, zField, analyzer);
     }
     
+
     /**
      * Creates a series by selecting rows and taking two values plus a constant y-value
      * 
@@ -165,7 +167,6 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
-
     /**
      * Creates a series by selecting rows and taking three values
      * 
@@ -238,6 +239,30 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
     /**
      * Creates a series by selecting rows and taking two values plus a constant y-value
      * 
@@ -266,7 +291,6 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
-
     /**
      * Creates a series by selecting rows, 
      * grouping by a constant x and applying two analyzers to y,
@@ -315,29 +339,6 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
 
     /**
      * Creates a series by selecting rows and taking a constant and two values
@@ -366,6 +367,7 @@ public class Series3D extends Series<Point3D>{
         }
     }
     
+
     /**
      * Creates a series by selecting rows, taking a constant x 
      * grouping by y and applying the analyzer to z 
@@ -430,7 +432,6 @@ public class Series3D extends Series<Point3D>{
         this(file, getDefaultSelector(), xLabel, yField, yAnalyzer, zAnalyzer);
     }
     
-
     /**
      * Creates a series by selecting rows and taking a constant and two values
      * 

--- a/src/main/de/linearbits/subframe/render/GnuPlotLinesClustered.java
+++ b/src/main/de/linearbits/subframe/render/GnuPlotLinesClustered.java
@@ -56,18 +56,18 @@ class GnuPlotLinesClustered extends GnuPlot<PlotLinesClustered> {
             String color = params.colorize ? "linecolor rgb \"#" + params.colors[i % params.colors.length] + "\" " : "";
             if (i == 0) {
                 if (params.categorialX) {
-                    command = "plot '" + filename + ".dat' using 2:xtic(1) with "+params.lineType+" "+color+"title col";
+                    command = "plot '" + filename + ".dat' using 2:xtic(1)";
                 } else {
-                    command = "plot '" + filename + ".dat' using 1:2 with \"+params.lineType+\" "+color+"title col";
+                    command = "plot '" + filename + ".dat' using 1:2";
                 }
             } else {
                 if (params.categorialX) {
-                    command = "     '' using " + (i + 2) + ":xtic(1) with \"+params.lineType+\" "+color+"title col";
+                    command = "     '' using " + (i + 2) + ":xtic(1)";
                 } else {
-                    command = "     '' using 1:" + (i + 2) + " with \"+params.lineType+\" "+color+"title col";
+                    command = "     '' using 1:" + (i + 2);
                 }
             }
-
+            command += " with " + params.lineType + " lw " + params.lineWidth + " " + color + "title col";
             if (i < size - 1) command += ",\\";
             gpCommands.add(command);
         }

--- a/src/main/de/linearbits/subframe/render/GnuPlotLinesClustered.java
+++ b/src/main/de/linearbits/subframe/render/GnuPlotLinesClustered.java
@@ -56,15 +56,15 @@ class GnuPlotLinesClustered extends GnuPlot<PlotLinesClustered> {
             String color = params.colorize ? "linecolor rgb \"#" + params.colors[i % params.colors.length] + "\" " : "";
             if (i == 0) {
                 if (params.categorialX) {
-                    command = "plot '" + filename + ".dat' using 2:xtic(1) with linespoints "+color+"title col";
+                    command = "plot '" + filename + ".dat' using 2:xtic(1) with "+params.lineType+" "+color+"title col";
                 } else {
-                    command = "plot '" + filename + ".dat' using 1:2 with linespoints "+color+"title col";
+                    command = "plot '" + filename + ".dat' using 1:2 with \"+params.lineType+\" "+color+"title col";
                 }
             } else {
                 if (params.categorialX) {
-                    command = "     '' using " + (i + 2) + ":xtic(1) with linespoints "+color+"title col";
+                    command = "     '' using " + (i + 2) + ":xtic(1) with \"+params.lineType+\" "+color+"title col";
                 } else {
-                    command = "     '' using 1:" + (i + 2) + " with linespoints "+color+"title col";
+                    command = "     '' using 1:" + (i + 2) + " with \"+params.lineType+\" "+color+"title col";
                 }
             }
 

--- a/src/main/de/linearbits/subframe/render/GnuPlotParams.java
+++ b/src/main/de/linearbits/subframe/render/GnuPlotParams.java
@@ -63,6 +63,34 @@ public class GnuPlotParams {
         }
     }
     
+    /**
+     * Class for line types
+     * @author Johanna Eicher
+     * @author Fabian Prasser
+     */
+    public static class LineType {
+
+        /** The position string */
+        private final String label;
+        
+        /**
+         * Creates a new instance
+         * @param label
+         */
+        private LineType(String label) {
+            this.label = label;
+        }
+        
+        @Override
+        public String toString() {
+            return this.label;
+        }
+        
+        public static final LineType LINESPOINTS = new LineType("linespoints");
+        public static final LineType LINES       = new LineType("lines");
+        public static final LineType STEPS       = new LineType("steps");
+    }
+    
     /** colourValues. */
     public String[] colors                  = new String[] { "1D4599", "11AD34", "E62B17",
                                             "E69F17", "2F3F60", "2F6C3D", "8F463F", "8F743F", "031A49",
@@ -144,15 +172,17 @@ public class GnuPlotParams {
     public String   printValuesFormatString = "%.2f";
     /** Offset for labels in the plot */
     public double   printValuesOffset       = +0.5d;
-    
-    /** Make the data a grid*/
-    public Integer  grid3dResolution = null;
-    /** Make the data a grid*/
-    public Integer  grid3dInterpolation = null;
-    /** Make the data a grid*/
-    public Integer xyPlaneAt = null;
-    
+
+    /** Make the data a grid */
+    public Integer  grid3dResolution        = null;
+    /** Make the data a grid */
+    public Integer  grid3dInterpolation     = null;
+    /** Make the data a grid */
+    public Integer  xyPlaneAt               = null;
+
     /** Font specification */
     public String   font                    = null;
 
+    /** The line type */
+    public LineType lineType                = LineType.LINESPOINTS;
 }

--- a/src/main/de/linearbits/subframe/render/GnuPlotParams.java
+++ b/src/main/de/linearbits/subframe/render/GnuPlotParams.java
@@ -185,4 +185,6 @@ public class GnuPlotParams {
 
     /** The line type */
     public LineType lineType                = LineType.LINESPOINTS;
+    /** The line width */
+    public double   lineWidth               = 1d;
 }


### PR DESCRIPTION
- Introduce a flag 'strict' indicating whether a Series3D can contain multiple Y-values for one single X-value.
- Enable clustered lines plots to handle X-Y-plots properly (Do not assume a fixed X-series)
- Make line types configurable.
- Make line width configurable.